### PR TITLE
Add column alignment option

### DIFF
--- a/advancedbrowser/advancedbrowser/config.py
+++ b/advancedbrowser/advancedbrowser/config.py
@@ -30,6 +30,8 @@ def getNoteModeShortcut():
 def getSelectable():
     return getUserOption().get("Table content", "No interaction")
 
+def getColumnAlignment():
+    return getUserOption().get("Column alignment", "Start")
 
 def update(_):
     global userOption

--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -84,13 +84,19 @@ class AdvancedBrowser:
         """Build a list of candidate columns. We extend the internal
         self.columns list with our custom types."""
         for key, column in self.customTypes.items():
+            alignmentConfig = config.getColumnAlignment()
+            if alignmentConfig == "Start":
+                alignment = BrowserColumns.ALIGNMENT_START
+            elif alignmentConfig == "Center":
+                alignment = BrowserColumns.ALIGNMENT_CENTER
+
             self.table._model.columns[key] = BuiltinColumn(
                 key=key,
                 cards_mode_label=column.name,
                 notes_mode_label=column.name,
                 sorting=BrowserColumns.SORTING_NORMAL if column.onSort() else BrowserColumns.SORTING_NONE,
                 uses_cell_font=False,
-                alignment=BrowserColumns.ALIGNMENT_START,
+                alignment=alignment,
             )
 
     def willSearch(self, ctx: SearchContext):

--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -90,7 +90,7 @@ class AdvancedBrowser:
                 notes_mode_label=column.name,
                 sorting=BrowserColumns.SORTING_NORMAL if column.onSort() else BrowserColumns.SORTING_NONE,
                 uses_cell_font=False,
-                alignment=BrowserColumns.ALIGNMENT_CENTER,
+                alignment=BrowserColumns.ALIGNMENT_START,
             )
 
     def willSearch(self, ctx: SearchContext):

--- a/advancedbrowser/config.json
+++ b/advancedbrowser/config.json
@@ -1,5 +1,6 @@
 {
   "Use a single list for fields":false,
   "Show internal fields": false,
-  "Table content": "Selectable"
+  "Table content": "Selectable",
+  "Column alignment": "Start"
 }

--- a/advancedbrowser/config.md
+++ b/advancedbrowser/config.md
@@ -8,3 +8,5 @@ The configuration options are:
   * "No interaction": the table content can't be interacted with
   * "Selectable": it can be selected. All edition will be ignored
   * "Editable": Allow to edit some values directly in the table. Not all.
+
+* "Column alignment": "Start" or "Center"

--- a/advancedbrowser/config.md
+++ b/advancedbrowser/config.md
@@ -9,4 +9,6 @@ The configuration options are:
   * "Selectable": it can be selected. All edition will be ignored
   * "Editable": Allow to edit some values directly in the table. Not all.
 
-* "Column alignment": "Start" or "Center"
+* "Column alignment": Either:
+  * "Start": text in column is left aligned
+  * "Center": text in column is center aligned

--- a/advancedbrowser/config.schema.json
+++ b/advancedbrowser/config.schema.json
@@ -15,6 +15,11 @@
       "type": "string",
       "enum": ["Editable", "Selectable", "No interaction"],
       "default": "Selectable"
+    },
+    "Column alignment" : {
+      "type": "string",
+      "enum": ["Start", "Center"],
+      "default": "Start"
     }
   }
 }


### PR DESCRIPTION
This PR adds a config option `"Column Alignment"` that can be set to either `"Start"` or `"Center"`.

It defaults to `"Start"`. This fixes #131﻿.

It uses Anki's [`BrowserColumns.Alignment.ALIGNMENT_START`](https://github.com/ankitects/anki/blob/5a055db02e7ded2e23ad857df1e78f65e2af6d96/proto/anki/search.proto#L142) value.