### PR TITLE
misc: fixes for 2.1.50 and qt6, better defaults (imo), better build script (imo)

### DIFF
--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -7,6 +7,7 @@ import time
 from anki.collection import BrowserColumns
 from anki.browser import BrowserConfig
 from anki.hooks import runHook, wrap
+from anki.utils import pointVersion
 from aqt import *
 from aqt import gui_hooks
 from aqt.browser import Column as BuiltinColumn, DataModel, SearchContext, CardState, NoteState
@@ -83,12 +84,13 @@ class AdvancedBrowser:
     def setupColumns(self):
         """Build a list of candidate columns. We extend the internal
         self.columns list with our custom types."""
+        bc = BrowserColumns.SORTING_NORMAL if pointVersion() <= 49 else BrowserColumns.SORTING_ASCENDING
         for key, column in self.customTypes.items():
             self.table._model.columns[key] = BuiltinColumn(
                 key=key,
                 cards_mode_label=column.name,
                 notes_mode_label=column.name,
-                sorting=BrowserColumns.SORTING_NORMAL if column.onSort() else BrowserColumns.SORTING_NONE,
+                sorting=bc if column.onSort() else BrowserColumns.SORTING_NONE,
                 uses_cell_font=False,
                 alignment=BrowserColumns.ALIGNMENT_CENTER,
             )

--- a/advancedbrowser/advancedbrowser/core.py
+++ b/advancedbrowser/advancedbrowser/core.py
@@ -48,7 +48,7 @@ class AdvancedBrowser:
         # Workaround for double-saving (see closeEvent)
         self.saveEvent = False
         if config.getSelectable() != "No interaction":
-            self.table._view.setEditTriggers(self.table._view.DoubleClicked)
+            self.table._view.setEditTriggers(self.table._view.EditTrigger.DoubleClicked)
 
     def newCustomColumn(self, type, name, onData, onSort=None,
                         setData=None, sortTableFunction=False):
@@ -151,7 +151,7 @@ class AdvancedBrowser:
                 row.cells[index].is_rtl = bool(fld and fld["rtl"])
 
     def setData(self, model, index, value, role):
-        if role not in (Qt.DisplayRole, Qt.EditRole):
+        if role not in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
             return False
         if config.getSelectable() != "Editable":
             return False
@@ -219,13 +219,13 @@ class AdvancedBrowser:
 def wrap_flags(self, index, _old):
     s = _old(self, index)
     if config.getSelectable() != "No interaction":
-        s |=  Qt.ItemIsEditable
+        s |=  Qt.ItemFlag.ItemIsEditable
     return s
 
 
 def wrap_data(self, index, role, _old):
-    if role == Qt.EditRole:
-        role = Qt.DisplayRole
+    if role == Qt.ItemDataRole.EditRole:
+        role = Qt.ItemDataRole.DisplayRole
     return _old(self, index, role)
 
 

--- a/advancedbrowser/config.json
+++ b/advancedbrowser/config.json
@@ -1,5 +1,5 @@
 {
   "Use a single list for fields":false,
   "Show internal fields": false,
-  "Table content": "Selectable"
+  "Table content": "No interaction"
 }

--- a/advancedbrowser/manifest.json
+++ b/advancedbrowser/manifest.json
@@ -1,4 +1,5 @@
 {
     "name": "Advanced Browser",
-    "package": "874215009"
+    "package": "874215009",
+    "branch_index": 4
 }

--- a/advancedbrowser/manifest.json
+++ b/advancedbrowser/manifest.json
@@ -1,0 +1,4 @@
+{
+    "name": "Advanced Browser",
+    "package": "874215009"
+}

--- a/release.py
+++ b/release.py
@@ -1,0 +1,32 @@
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import time
+
+     
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+code_folder = os.path.join(scriptdir, "advancedbrowser")
+tmp_dir = tempfile.mkdtemp()
+manifest_in_json = os.path.join(tmp_dir, "manifest.json")
+
+if sys.version_info.minor >= 8:
+    shutil.copytree(code_folder, tmp_dir, dirs_exist_ok=True)
+else:
+    print("Aborting. This build script only supports python 3.8 or later")
+    sys.exit()
+
+with open(manifest_in_json, "r") as f:
+    data = json.load(f)
+data["mod"] = int(time.time())
+with open(manifest_in_json, "w") as f:
+    json.dump(data, f)
+
+target_zip_file = os.path.join(scriptdir, f"advanced_browser__{time.strftime('%Y-%m-%d_%H-%M')}")
+shutil.make_archive(target_zip_file, 'zip', tmp_dir)
+p = Path(f"{target_zip_file}.zip")
+p.rename(p.with_suffix('.ankiaddon'))
+
+shutil.rmtree(tmp_dir)

--- a/release.sh
+++ b/release.sh
@@ -1,2 +1,0 @@
- 
-git archive -o advanced-browser.zip HEAD:advancedbrowser


### PR DESCRIPTION
these changes need some testing.

the new build script and default is just my preference, not sure if they are an actual improvement for other people.

the code of the advanced browser usually only targets the latest version, i.e. there's no use of pointVersion in the code so far. I added it nevertheless because it's only one change between 2.1.45 and 2.1.50 and I wanted to avoid another version. the new enum style that qt6 requires also should work on new-ish qt5 versions (that all recent official anki builds use).