### PR TITLE
Anki func rename: stripHTMLMedia->strip_html_media

### DIFF
--- a/advancedbrowser/advancedbrowser/note_fields.py
+++ b/advancedbrowser/advancedbrowser/note_fields.py
@@ -4,6 +4,7 @@
 import re
 from anki.cards import Card
 from anki.hooks import addHook
+from anki.utils import pointVersion
 from aqt import *
 from aqt.utils import showWarning
 
@@ -157,7 +158,7 @@ class NoteFields:
         s = s.replace("\n", " ")
         s = reSound.sub("\\1", s)  # this line is different
         s = reType.sub("", s)
-        s = anki.utils.stripHTMLMedia(s)
+        s = anki.utils.stripHTMLMedia(s) if pointVersion() < 50 else anki.utils.strip_html_media(s)
         s = s.strip()
         return s
 


### PR DESCRIPTION
I run anki from the command line to see deprecation warnings etc. 

stripHTMLMedia is called a lot by the NB and since it's also deprecated my terminal gets flooded with this one message which I find inconvenient.